### PR TITLE
Fix fetcher escape warning and add command validation

### DIFF
--- a/core/tools/fetcher.py
+++ b/core/tools/fetcher.py
@@ -303,7 +303,7 @@ class SystemFetcher:
             
             if self.is_windows:
                 # Windows performance counters
-                ps_cmd = """
+                ps_cmd = r"""
                 Get-Counter -Counter @(
                     '\Processor(_Total)\% Processor Time',
                     '\Memory\Available MBytes',


### PR DESCRIPTION
## Summary
- fix `ps_cmd` string literal in `fetcher.py`
- introduce command validation helpers in `executor.py`
- block execution of non-shell text in `Executor` methods
- apply validation to global `execute_action`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684151aa268c8333a7f22e97d248d4ff