### PR TITLE
Improve shell command validation

### DIFF
--- a/core/agent_loop.py
+++ b/core/agent_loop.py
@@ -18,7 +18,7 @@ import asyncio
 from core import planner, evolver
 from core.memory import Memory
 from core.audit import AuditLogger
-from core.executor import Executor, is_likely_shell_command
+from core.executor import Executor, is_valid_shell_command
 from core.goal_gen import GoalGenerator
 from core.goal_router import GoalRouter
 from core.utils import suggest_tags
@@ -1014,7 +1014,7 @@ class Agent:
             # Remove timeout from kwargs if present to avoid duplicate parameter
             kwargs.pop('timeout', None)
 
-            if not is_likely_shell_command(command):
+            if not is_valid_shell_command(command):
                 logger.warning("Skipped invalid shell command: %s", command)
                 return {
                     "status": "error",

--- a/core/executor_modules.py
+++ b/core/executor_modules.py
@@ -1,8 +1,7 @@
 # core/executor_modules.py
 
 import subprocess
-import shlex
-from core.executor import is_likely_shell_command
+from core.executor import is_valid_shell_command
 from pathlib import Path
 from typing import Optional
 
@@ -13,10 +12,11 @@ class ExecutorsModule:
     def run_shell_command(command: str) -> str:
         """Run a shell command and return the output or error"""
         try:
-            if not is_likely_shell_command(command):
+            if not is_valid_shell_command(command):
                 return "[ERROR] Rejected non-shell command"
             result = subprocess.run(
-                shlex.split(command),
+                command,
+                shell=True,
                 capture_output=True,
                 text=True,
                 timeout=20

--- a/core/tools/shell.py
+++ b/core/tools/shell.py
@@ -1,9 +1,13 @@
-from core.executor import is_likely_shell_command
+from core.executor import is_valid_shell_command
+import logging
+
+logger = logging.getLogger(__name__)
 
 def run_shell(command: str) -> dict:
     """Execute a shell command and return standardized output"""
     try:
-        if not is_likely_shell_command(command):
+        if not is_valid_shell_command(command):
+            logger.warning("Skipped invalid shell command: %s", command)
             return {"status": "error", "output": "Rejected non-shell command", "returncode": -1}
         import subprocess
         result = subprocess.run(

--- a/core/tools/tool_registry.py
+++ b/core/tools/tool_registry.py
@@ -176,14 +176,14 @@ def run_shell(command: str, timeout: int = 60, **kwargs) -> dict:
     Execute a shell command safely and always return a dictionary.
     """
     try:
-        from core.executor import Executor, is_likely_shell_command
+        from core.executor import Executor, is_valid_shell_command
         exec_ = Executor()
-        if not is_likely_shell_command(command):
+        if not is_valid_shell_command(command):
             logger.warning("Skipped invalid shell command: %s", command)
             return {"status": "error", "output": "Rejected non-shell command"}
         # Remove timeout from kwargs since we're passing it explicitly
         kwargs.pop('timeout', None)
-        proc = exec_.run_and_capture(command.split(), timeout=timeout)
+        proc = exec_.run_and_capture(command, timeout=timeout)
         
         # Always return a properly formatted dictionary
         if isinstance(proc, str):


### PR DESCRIPTION
## Summary
- add `is_valid_shell_command` with better heuristics
- use new validator throughout executor and tools
- allow multi-line commands by running them in shell mode
- log skipped commands via logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415744d634833393247bc04993035b