### PR TITLE
Add LLM output classification for safer shell execution

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -209,6 +209,13 @@ class Executor:
             # Sanitize command
             command = self.sanitize_command(goal_description)
 
+            from core.intent_classifier import classify_llm_output
+            classification = classify_llm_output(command)
+            ctype = classification.get("type", "other")
+            LOGGER.info("Command classification: %s - %s", ctype, command)
+            if ctype != "command":
+                return f"[SKIPPED] {ctype}"
+
             if not is_valid_shell_command(command):
                 LOGGER.warning("Rejected non-shell command: %s", command)
                 return "[ERROR] Rejected non-shell command"
@@ -337,6 +344,13 @@ def execute_action(command: str) -> str:
     try:
         # Sanitize command for safety
         command = re.sub(r'[`;&|]', '', command).strip()
+
+        from core.intent_classifier import classify_llm_output
+        classification = classify_llm_output(command)
+        ctype = classification.get("type", "other")
+        LOGGER.info("Command classification: %s - %s", ctype, command)
+        if ctype != "command":
+            return f"[SKIPPED] {ctype}"
 
         if not is_valid_shell_command(command):
             LOGGER.warning("Skipped invalid shell command: %s", command)

--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -1,0 +1,38 @@
+import json
+import logging
+from typing import Dict
+
+from .chat import chat_with_llm
+
+logger = logging.getLogger(__name__)
+
+_CLASSIFY_PROMPT = (
+    "You are an intent classifier. Categorize the given text into one of the"
+    " following types: command, explanation, instruction, error, suggestion,"
+    " other. Respond ONLY with JSON like {\"type\": \"command\"}."
+)
+
+
+def classify_llm_output(text: str) -> Dict[str, str]:
+    """Classify LLM output text into an intent type using the LLM itself."""
+    text = (text or "").strip()
+    if not text:
+        return {"type": "other"}
+    try:
+        response = chat_with_llm(
+            user_input=f"Text:\n{text}",
+            system_prompt=_CLASSIFY_PROMPT,
+            format="json",
+            retry_on_invalid=True,
+        )
+        data = json.loads(response)
+        if isinstance(data, dict) and data.get("type"):
+            return {"type": str(data["type"]).lower()}
+    except Exception as e:
+        logger.error("LLM classification failed: %s", e)
+    # Fallback heuristic
+    try:
+        from .executor import is_valid_shell_command
+        return {"type": "command" if is_valid_shell_command(text) else "other"}
+    except Exception:
+        return {"type": "other"}


### PR DESCRIPTION
## Summary
- add `core.intent_classifier` using LLM or heuristics to determine intent type
- integrate classifier into `run_shell` tool and executor action helpers
- skip or warn on non-command outputs before execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415a7a605483338c4f944e54612447